### PR TITLE
fix(plugin-name): add explicit plugin name

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,7 @@ const Sequelize = require('sequelize');
 module.exports = {
     pkg: Pkg,
     once: true,
-    configKey: 'sequelize',
+    name: 'sequelize',
     register,
 };
 


### PR DESCRIPTION
Change plugin name from `@bakjs/sequelize` to `sequelize`